### PR TITLE
XCUITest support

### DIFF
--- a/Xtc/src/Xtc.TestCloud/Commands/UploadAppiumTestsCommandExecutor.cs
+++ b/Xtc/src/Xtc.TestCloud/Commands/UploadAppiumTestsCommandExecutor.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Xtc.TestCloud.Commands
     /// <summary>
     /// Command executor that uploads Appium tests to the Test Cloud.
     /// </summary>
-    public class UploadAppiumTestsCommandExecutor : UploadJUnitTestsCommandExecutor
+    public class UploadAppiumTestsCommandExecutor : UploadXTCTestCommandExecutor
     {
         public UploadAppiumTestsCommandExecutor(
             UploadTestsCommandOptions options, ILoggerService loggerService, LogsRecorder logsRecorder) : base(options, loggerService, logsRecorder)

--- a/Xtc/src/Xtc.TestCloud/Commands/UploadEspressoTestsCommandExecutor.cs
+++ b/Xtc/src/Xtc.TestCloud/Commands/UploadEspressoTestsCommandExecutor.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Xtc.TestCloud.Commands
     /// <summary>
     /// Command executor that uploads Espresso tests to the Test Cloud.
     /// </summary>
-    public class UploadEspressoTestsCommandExecutor : UploadJUnitTestsCommandExecutor
+    public class UploadEspressoTestsCommandExecutor : UploadXTCTestCommandExecutor
     {
         public UploadEspressoTestsCommandExecutor(UploadTestsCommandOptions options, ILoggerService loggerService, LogsRecorder logsRecorder) : base(options, loggerService, logsRecorder)
         {

--- a/Xtc/src/Xtc.TestCloud/Commands/UploadTestsCommand.cs
+++ b/Xtc/src/Xtc.TestCloud/Commands/UploadTestsCommand.cs
@@ -56,9 +56,20 @@ Options: {UploadTestsCommandOptions.OptionsDescription}";
             {
                 return new UploadAppiumTestsCommandExecutor(uploadOptions, loggerService, logsRecorder);
             } 
-            else
+            else if (WorkspaceHelper.IsEspressoWorkspace(uploadOptions.Workspace))
             {
                 return new UploadEspressoTestsCommandExecutor(uploadOptions, loggerService, logsRecorder);
+            }
+            else if (WorkspaceHelper.IsXCUITestWorkspace(uploadOptions.Workspace))
+            {
+                return new UploadXCUITestCommandExecutor(uploadOptions, loggerService, logsRecorder);
+            }
+            else
+            {
+                throw new CommandException(
+                    UploadTestsCommand.CommandName,
+                    @"Unable to recognize workspace format",
+                    (int) UploadCommandExitCodes.InvalidWorkspace);
             }
         }
     }

--- a/Xtc/src/Xtc.TestCloud/Commands/UploadTestsCommandOptions.cs
+++ b/Xtc/src/Xtc.TestCloud/Commands/UploadTestsCommandOptions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Xtc.TestCloud.Commands
     <app-file>                           - An Android or iOS application to test.
     <api-key>                            - Test Cloud API key.
     --user <user>                        - Email address of the user.
-    --workspace <workspace>              - Path to the workspace folder (containing your tests [appium] or test apk [espresso]).
+    --workspace <workspace>              - Path to the workspace folder (containing your tests).
     --app-name <app-name>                - App name to create or add tests to.
     --devices <devices>                  - Device selection id from the Test Cloud upload dialog.
     --async                              - Don't wait for the Test Cloud run to complete.

--- a/Xtc/src/Xtc.TestCloud/Commands/UploadXCUITestCommandExecutor.cs
+++ b/Xtc/src/Xtc.TestCloud/Commands/UploadXCUITestCommandExecutor.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Xtc.Common.Services.Logging;
+using Microsoft.Xtc.TestCloud.ObjectModel;
+using Microsoft.Xtc.TestCloud.Utilities;
+using Microsoft.Xtc.Common.Cli.Commands;
+
+namespace Microsoft.Xtc.TestCloud.Commands
+{
+    /// <summary>
+    /// Command executor that uploads XCUITest tests to the Test Cloud.
+    /// </summary>
+    public class UploadXCUITestCommandExecutor : UploadXTCTestCommandExecutor
+    {
+        public UploadXCUITestCommandExecutor(UploadTestsCommandOptions options, ILoggerService loggerService, LogsRecorder logsRecorder) : base(options, loggerService, logsRecorder)
+        {
+            this.TestName = "XCUITest";
+            this.Workspace = new XCUITestWorkspace(options.Workspace);
+        }
+
+        protected override void ValidateOptions()
+        {
+            if (ValidationHelper.IsAndroidApp(_options.AppFile)) 
+            {
+                throw new CommandException(
+                    UploadTestsCommand.CommandName,
+                    @"Application file must be an iOS application (.ipa) file.",
+                    (int) UploadCommandExitCodes.InvalidAppFile);
+            } 
+            base.ValidateOptions();
+        }
+    }
+}

--- a/Xtc/src/Xtc.TestCloud/Commands/UploadXCUITestCommandExecutor.cs
+++ b/Xtc/src/Xtc.TestCloud/Commands/UploadXCUITestCommandExecutor.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Xtc.TestCloud.Commands
     {
         public UploadXCUITestCommandExecutor(UploadTestsCommandOptions options, ILoggerService loggerService, LogsRecorder logsRecorder) : base(options, loggerService, logsRecorder)
         {
-            this.TestName = "XCUITest";
+            this.TestName = "xcuitest";
             this.Workspace = new XCUITestWorkspace(options.Workspace);
         }
 

--- a/Xtc/src/Xtc.TestCloud/Commands/UploadXTCTestCommandExecutor.cs
+++ b/Xtc/src/Xtc.TestCloud/Commands/UploadXTCTestCommandExecutor.cs
@@ -18,9 +18,9 @@ using LoggerExtensions = Microsoft.Xtc.Common.Services.Logging.LoggerExtensions;
 namespace Microsoft.Xtc.TestCloud.Commands
 {
     /// <summary>
-    /// Command executor that uploads Appium tests to the Test Cloud.
+    /// Generic command executor for currently supported XTC tests
     /// </summary>
-    public class UploadJUnitTestsCommandExecutor : ICommandExecutor
+    public class UploadXTCTestCommandExecutor : ICommandExecutor
     {
         private const string TestCloudEndpointEnvironmentVariable = "XTC_ENDPOINT"; 
 
@@ -46,7 +46,7 @@ namespace Microsoft.Xtc.TestCloud.Commands
         protected IWorkspace Workspace { get { return _workspace; } set { _workspace = value; } }
         protected string TestName { get { return _testName; } set { _testName = value; } }
 
-        public UploadJUnitTestsCommandExecutor(UploadTestsCommandOptions options, ILoggerService loggerService, LogsRecorder logsRecorder)
+        public UploadXTCTestCommandExecutor(UploadTestsCommandOptions options, ILoggerService loggerService, LogsRecorder logsRecorder)
         {
             if (options == null)
                 throw new ArgumentNullException(nameof(options));
@@ -55,7 +55,7 @@ namespace Microsoft.Xtc.TestCloud.Commands
 
             _options = options;
             _logsRecorder = logsRecorder;
-            _logger = loggerService.CreateLogger<UploadJUnitTestsCommandExecutor>();
+            _logger = loggerService.CreateLogger<UploadXTCTestCommandExecutor>();
             
             var testCloudUri = GetTestCloudUri();
             _testCloudProxy = new TestCloudProxy(testCloudUri, loggerService);

--- a/Xtc/src/Xtc.TestCloud/ObjectModel/XCUITestWorkspace.cs
+++ b/Xtc/src/Xtc.TestCloud/ObjectModel/XCUITestWorkspace.cs
@@ -10,17 +10,17 @@ using Microsoft.Xtc.TestCloud.Utilities;
 namespace Microsoft.Xtc.TestCloud.ObjectModel
 {
     /// <summary>
-    /// Represents an Espresso workspace directory.
+    /// Represents an XCUITest workspace directory.
     /// </summary>
-    public class EspressoWorkspace : IWorkspace
+    public class XCUITestWorkspace : IWorkspace
     {
         private readonly string _workspacePath;
 
         /// <summary>
-        /// Constructor. Creates new instance of the Espresso Workspace.
+        /// Constructor. Creates new instance of the XCUITest Workspace.
         /// </summary>
         /// <param name="workspacePath">Path to the workspace directory.</param>
-        public EspressoWorkspace(string workspacePath)
+        public XCUITestWorkspace(string workspacePath)
         {
             if (workspacePath == null)
                 throw new ArgumentNullException(nameof(workspacePath));
@@ -33,7 +33,7 @@ namespace Microsoft.Xtc.TestCloud.ObjectModel
         /// </summary>
         public void Validate() 
         {
-            ValidateContainsOneTestApk();
+            ValidateContainsXCUITestBundle();
         }
 
         /// <summary>
@@ -55,22 +55,25 @@ namespace Microsoft.Xtc.TestCloud.ObjectModel
             if (hashAlgorithm == null)
                 throw new ArgumentNullException(nameof(hashAlgorithm));
             
-            var testApk = Directory.GetFiles(workspacePath, "*-androidTest.apk", SearchOption.TopDirectoryOnly).Single();
-            var relativePath = FileHelper.GetRelativePath(testApk, workspacePath);
-            var hash = hashAlgorithm.GetFileHash(testApk);
+            var testRunner = Directory.GetFiles(workspacePath, "*-Runner.ipa", SearchOption.TopDirectoryOnly).Single();
+            var relativePath = FileHelper.GetRelativePath(testRunner, workspacePath);
+            var hash = hashAlgorithm.GetFileHash(testRunner);
 
-            return new List<UploadFileInfo> {new UploadFileInfo(testApk, relativePath, hash)};
+            return new List<UploadFileInfo> {new UploadFileInfo(testRunner, relativePath, hash)};
         }
 
 
-        protected void ValidateContainsOneTestApk()
+        protected void ValidateContainsXCUITestBundle()
         {
-            var apks = Directory.GetFiles(_workspacePath, "*-androidTest.apk", SearchOption.TopDirectoryOnly);
-            if (apks.Length != 1)
+            //TODO:
+            //We could unzip the .ipa and validate that it has an .xctest bundle and xctestconfiguration file
+            //which points to the target application. 
+            var testRunners = Directory.GetFiles(_workspacePath, "*-Runner.ipa", SearchOption.TopDirectoryOnly);
+            if (testRunners.Length != 1)
             {
                 throw new CommandException(
                     UploadTestsCommand.CommandName,
-                    "Espresso workspace directory must contain exactly one test apk file (which ends with -androidTest.apk).",
+                    "XCUITestWorkspace directory must contain exactly one test runner (should end in '-Runner.ipa')",
                     (int)UploadCommandExitCodes.InvalidWorkspace);
             }
         }

--- a/Xtc/src/Xtc.TestCloud/Utilities/WorkspaceHelper.cs
+++ b/Xtc/src/Xtc.TestCloud/Utilities/WorkspaceHelper.cs
@@ -30,6 +30,48 @@ namespace Microsoft.Xtc.TestCloud.Utilities
         }
 
         /// <summary>
+        /// Convenience method for determining if workspace is an Espresso Workspace
+        /// </summary>
+        /// <param name="workspacePath">Path to the workspace directory.</param>
+        /// <return>true if the workspace is appropriate for an appium test
+        public static bool IsEspressoWorkspace(string workspacePath)
+        {
+            if (workspacePath == null)
+                throw new ArgumentNullException(nameof(workspacePath));
+
+            try 
+            {
+                new EspressoWorkspace(workspacePath).Validate();
+            }
+            catch (CommandException) 
+            {
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Convenience method for determining if workspace is an XCUITest Workspace
+        /// </summary>
+        /// <param name="workspacePath">Path to the workspace directory.</param>
+        /// <return>true if the workspace is appropriate for an appium test
+        public static bool IsXCUITestWorkspace(string workspacePath)
+        {
+            if (workspacePath == null)
+                throw new ArgumentNullException(nameof(workspacePath));
+
+            try 
+            {
+                new XCUITestWorkspace(workspacePath).Validate();
+            }
+            catch (CommandException) 
+            {
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
         /// Returns all files from the workspace that should be uploaded.
         /// </summary>
         /// <returns>List with all files from the workspace directory.</returns>


### PR DESCRIPTION
# Motivation

Allow XCUITest uploads. 

Defines a new type of workspace, `XCUITestWorkspace`, which describes a workspace containing exactly one `*-Runner.ipa`, which is the naming convention given to test runners produced by Xcode. 

