### PR TITLE
Print test type during upload

### DIFF
--- a/Xtc/src/Xtc.TestCloud/Commands/UploadTestsCommandOptions.cs
+++ b/Xtc/src/Xtc.TestCloud/Commands/UploadTestsCommandOptions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Xtc.TestCloud.Commands
 
         public static readonly string[] OptionsSyntax =
         {
-            "<app-file> <api-key> --user <user> --devices <devices> [options]"
+            "<app-file> <api-key> --user <user> --devices <devices> --workspace <workspace> [options]"
         };
 
         private readonly IDictionary<string, ValueObject> _options;

--- a/Xtc/src/Xtc.TestCloud/Commands/UploadXTCTestCommandExecutor.cs
+++ b/Xtc/src/Xtc.TestCloud/Commands/UploadXTCTestCommandExecutor.cs
@@ -307,7 +307,8 @@ http://docs.xamarin.com/guides/android/deployment%2C_testing%2C_and_metrics/publ
             var logLines = new List<string>
             {
                 "Tests enqueued",
-                $"User: {response.UserEmail}"
+                $"User: {response.UserEmail}",
+                $"Test Type: {response.TestType}"
             };
 
             if (response.Team != null)

--- a/Xtc/src/Xtc.TestCloud/ObjectModel/UploadTestsResult.cs
+++ b/Xtc/src/Xtc.TestCloud/ObjectModel/UploadTestsResult.cs
@@ -28,6 +28,12 @@ namespace Microsoft.Xtc.TestCloud.ObjectModel
         public string Team { get; set; }
 
         /// <summary>
+        /// Type of Test (e.g. Appium, Espreso, etc.)
+        /// </summary>
+        [JsonProperty("type")]
+        public string TestType { get; set; }
+
+        /// <summary>
         /// List of rejected devices.
         /// </summary>
         [JsonProperty("rejected_devices")]


### PR DESCRIPTION
# Motivation

Was debugging an issue where test was uploading without any `--workspace` option, and realized it'd be nice if we had a way to know what kind of test XTC thought it was receiving. 

This pairs with changes in https://github.com/xamarin/test-cloud-frontend/pull/2601