### PR TITLE
XCUITest workspace now based on *-Runner.app

### DIFF
--- a/Xtc/src/Xtc.TestCloud/ObjectModel/XCUITestWorkspace.cs
+++ b/Xtc/src/Xtc.TestCloud/ObjectModel/XCUITestWorkspace.cs
@@ -55,20 +55,18 @@ namespace Microsoft.Xtc.TestCloud.ObjectModel
             if (hashAlgorithm == null)
                 throw new ArgumentNullException(nameof(hashAlgorithm));
             
-            var testRunner = Directory.GetFiles(workspacePath, "*-Runner.ipa", SearchOption.TopDirectoryOnly).Single();
-            var relativePath = FileHelper.GetRelativePath(testRunner, workspacePath);
-            var hash = hashAlgorithm.GetFileHash(testRunner);
+            var testRunnerApp = Directory.GetDirectories(workspacePath, "*-Runner.app", SearchOption.TopDirectoryOnly).Single();
+            var testRunnerIpa = FileHelper.ArchiveAppBundle(testRunnerApp);
+            var relativePath = FileHelper.GetRelativePath(testRunnerIpa, workspacePath);
+            var hash = hashAlgorithm.GetFileHash(testRunnerIpa);
 
-            return new List<UploadFileInfo> {new UploadFileInfo(testRunner, relativePath, hash)};
+            return new List<UploadFileInfo> {new UploadFileInfo(testRunnerIpa, relativePath, hash)};
         }
 
 
         protected void ValidateContainsXCUITestBundle()
         {
-            //TODO:
-            //We could unzip the .ipa and validate that it has an .xctest bundle and xctestconfiguration file
-            //which points to the target application. 
-            var testRunners = Directory.GetFiles(_workspacePath, "*-Runner.ipa", SearchOption.TopDirectoryOnly);
+            var testRunners = Directory.GetDirectories(_workspacePath, "*-Runner.app", SearchOption.TopDirectoryOnly);
             if (testRunners.Length != 1)
             {
                 throw new CommandException(


### PR DESCRIPTION
# Motivation

We want users to specify `--workspace Build/Products/Debug-iphoneos` when uploading an XCUITest, which means we need to accept the test runner as a .app instead of a .ipa. 

This means the uploader needs to archive it prior to upload. 

# Notes

1. No tests for archive functionality. This would require integration tests (i.e. we'd need to include some .app in the repo etc. Worth doing now?)

2. Even though the user can now specify a `--workspace Build/Products/Debug-iphoneos`, they still need to specify their application in .ipa format. Unless we can do away with the application argument altogether for XCUITests, I think the cli will be awkward:

```shell
$ xtc test MyApp.ipa <api_key> --devices bbfa5de1 --user <my_email> --workspace ~/Somewhere/Build/Products/Debug-iphoneos/
```
This is an awkward workflow because `MyApp.app` is already in the workspace, but the client will manually need to zip it themselves first or create an .ipa archive through Xcode/`xcodebuild` etc. 

Accepting a `.app` for the application argument is similarly awkward:

```shell
$ xtc test ~/Somewhere/Build/Products/Debug-iphoneos/MyApp.app <api_key> --devices bbfa5de1 --user <my_email> --workspace ~/Somewhere/Build/Products/Debug-iphoneos/
```

The point of the current [build instructions](https://github.com/xamarinhq/test-cloud-xcuitest-extensions/blob/master/README.md#preparing-your-application-bundles) utilizing `build-for-test` is that we get both the application and test runner built with a single command. Ideally, the user would be able to do something like this:

```shell
$ xtc test <api_key> --devices bbfa5de1 --user <my_email> --workspace ~/Somewhere/Build/Products/Debug-iphoneos/
```
Since we can extract both the application and runner from the same dir and upload them, presumably freshly built. However, this will require making the application argument optional, which might be a bad experience for other test types. 