### PR TITLE
Feature/update xcuitest upload

### DIFF
--- a/Xtc/src/Xtc.Cli/Commands/HelpCommand.cs
+++ b/Xtc/src/Xtc.Cli/Commands/HelpCommand.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using DocoptNet;
-using Microsoft.Xtc.Common;
 using Microsoft.Xtc.Common.Cli.Commands;
 using Microsoft.Xtc.Common.Cli.Utilities;
 

--- a/Xtc/src/Xtc.Cli/Program.cs
+++ b/Xtc/src/Xtc.Cli/Program.cs
@@ -116,6 +116,7 @@ If you are using MacPorts (https://www.macports.org/), execute this command:
             registry.AddCommand(new HelpCommandDescription());
             registry.AddCommand(new RunExtensionCommandDescription());
             registry.AddCommand(new UploadTestsCommand());
+            registry.AddCommand(new UploadXCUITestsCommand());
 
             return registry;
         }

--- a/Xtc/src/Xtc.TestCloud/Commands/IUploadTestCommandOptions.cs
+++ b/Xtc/src/Xtc.TestCloud/Commands/IUploadTestCommandOptions.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using DocoptNet;
+using Microsoft.Xtc.Common.Cli.Commands;
+
+namespace Microsoft.Xtc.TestCloud.Commands
+{
+    public abstract class IUploadTestsCommandOptions
+    {
+
+        public const string AppFileOption = "<app-file>";
+        public const string ApiKeyOption = "<api-key>";
+        public const string UserOption = "--user";
+        public const string WorkspaceOption = "--workspace";
+        public const string AppNameOption = "--app-name";
+        public const string DevicesOption = "--devices";
+        public const string TestParametersOption = "--test-parameters";
+        public const string AsyncOption = "--async";
+        public const string AsyncJsonOption = "--async-json";
+        public const string LocaleOption = "--locale";
+        public const string SeriesOption = "--series";
+        public const string DSymDirectoryOption = "--dsym-directory";
+        public const string DebugOption = "--debug";
+
+        protected readonly IDictionary<string, ValueObject> _options;
+        protected IList<KeyValuePair<string, string>> _parsedTestParameters;
+
+        public IUploadTestsCommandOptions(IDictionary<string, ValueObject> options)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            _options = options;
+            _parsedTestParameters = null;
+        }
+    
+        public virtual string AppFile
+        {
+            get {  return _options[AppFileOption].ToString(); }
+        }
+
+        public string ApiKey
+        {
+            get { return _options[ApiKeyOption].ToString(); }
+        }
+
+        public string User
+        {
+            get { return _options[UserOption]?.ToString(); }
+        }
+
+        public string Workspace
+        {
+            get { return _options[WorkspaceOption]?.ToString(); }
+        }
+
+        public string AppName
+        {
+            get { return _options[AppNameOption]?.ToString(); }
+        }
+
+        public string Devices
+        {
+            get { return _options[DevicesOption]?.ToString(); }
+        }
+
+
+        public IList<KeyValuePair<string, string>> TestParameters
+        {
+            get 
+            {
+                if (_parsedTestParameters == null)
+                    _parsedTestParameters = ParseTestParameters(_options[TestParametersOption]?.ToString()).ToList();
+                 
+                return _parsedTestParameters;
+            }
+        }
+
+        public bool Async
+        {
+            get { return _options[AsyncOption].IsTrue; }
+        }
+
+        public bool AsyncJson
+        {
+            get { return _options[AsyncJsonOption].IsTrue; }
+        }
+
+        public string Locale
+        {
+            get { return _options[LocaleOption]?.ToString() ?? "en_US"; }
+        }
+
+        public string Series
+        {
+            get { return _options[SeriesOption]?.ToString(); }
+        }
+
+        public string DSymDirectory
+        {
+            get { return _options[DSymDirectoryOption]?.ToString(); }
+        }
+
+        public bool Debug
+        {
+            get { return _options[DebugOption].IsTrue; }
+        }
+
+        public abstract void Validate();
+
+        protected IEnumerable<KeyValuePair<string, string>> ParseTestParameters(string testParametersString)
+        {
+            if (string.IsNullOrWhiteSpace(testParametersString))
+                return Enumerable.Empty<KeyValuePair<string, string>>();
+
+            var regex = new Regex("((?<key>.+):(?<value>.+))");
+            var pairs = Regex.Split(testParametersString, "\\s*,\\s*");
+            
+            if (pairs.Any(p => !regex.IsMatch(p)))
+            {
+                throw new CommandException(
+                    UploadTestsCommand.CommandName, 
+                    $"Argument {TestParametersOption} is not formatted correctly", 
+                    (int)UploadCommandExitCodes.InvalidOptions);
+            }
+                
+            return pairs
+                .Select(pair => {
+                    var match = regex.Match(pair);
+                    return new KeyValuePair<string, string>(match.Groups["key"].Value, match.Groups["value"].Value);
+                });
+        }
+
+        public IList<string> ToArgumentsArray()
+        {
+            var result = new List<string>();
+
+            foreach (var keyValue in _options)
+            {
+                if (keyValue.Value != null)
+                {
+                    result.Add(keyValue.Key);
+                    if (keyValue.Value.IsString)
+                        result.Add(keyValue.Value.ToString());
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/Xtc/src/Xtc.TestCloud/Commands/UploadCommandExitCodes.cs
+++ b/Xtc/src/Xtc.TestCloud/Commands/UploadCommandExitCodes.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Xtc.TestCloud.Commands
         InvalidDSymDirectory = 6,
         InvalidOptions = 7,
         InvalidTestCloudEndpoint = 8,
-        ServerError = 9
+        ServerError = 9,
+        MissingAppFile = 10
     }
 }

--- a/Xtc/src/Xtc.TestCloud/Commands/UploadTestsCommand.cs
+++ b/Xtc/src/Xtc.TestCloud/Commands/UploadTestsCommand.cs
@@ -24,13 +24,13 @@ namespace Microsoft.Xtc.TestCloud.Commands
 Usage:
 {GetPossibleOptionSyntax()}
 
-Options: {UploadTestsCommandOptions.OptionsDescription}";
+Options: {UploadTestsCommandOptions.OptionsDescription()}";
 
         private string GetPossibleOptionSyntax()
         {
             var result = new StringBuilder();
 
-            foreach (var syntax in UploadTestsCommandOptions.OptionsSyntax)
+            foreach (var syntax in UploadTestsCommandOptions.OptionsSyntax())
             {
                 result.AppendFormat($"    {ProgramUtilities.CurrentExecutableName} {this.Name} {syntax}");
             }
@@ -59,10 +59,6 @@ Options: {UploadTestsCommandOptions.OptionsDescription}";
             else if (WorkspaceHelper.IsEspressoWorkspace(uploadOptions.Workspace))
             {
                 return new UploadEspressoTestsCommandExecutor(uploadOptions, loggerService, logsRecorder);
-            }
-            else if (WorkspaceHelper.IsXCUITestWorkspace(uploadOptions.Workspace))
-            {
-                return new UploadXCUITestCommandExecutor(uploadOptions, loggerService, logsRecorder);
             }
             else
             {

--- a/Xtc/src/Xtc.TestCloud/Commands/UploadTestsCommandOptions.cs
+++ b/Xtc/src/Xtc.TestCloud/Commands/UploadTestsCommandOptions.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using DocoptNet;
 using Microsoft.Xtc.Common.Cli.Commands;
 
@@ -11,68 +9,41 @@ namespace Microsoft.Xtc.TestCloud.Commands
     /// <summary>
     /// Represents command-line options for 'test' command.
     /// </summary>
-    public class UploadTestsCommandOptions
+    public class UploadTestsCommandOptions: IUploadTestsCommandOptions
     {
-        public const string AppFileOption = "<app-file>";
-        public const string ApiKeyOption = "<api-key>";
-        public const string UserOption = "--user";
-        public const string WorkspaceOption = "--workspace";
-        public const string AppNameOption = "--app-name";
-        public const string DevicesOption = "--devices";
-        public const string TestParametersOption = "--test-parameters";
-        public const string AsyncOption = "--async";
-        public const string AsyncJsonOption = "--async-json";
-        public const string LocaleOption = "--locale";
-        public const string SeriesOption = "--series";
-        public const string DSymDirectoryOption = "--dsym-directory";
-        public const string DebugOption = "--debug";
-
-        public const string OptionsDescription = @"
-    <app-file>                           - An Android or iOS application to test.
-    <api-key>                            - Test Cloud API key.
-    --user <user>                        - Email address of the user.
-    --workspace <workspace>              - Path to the workspace folder (containing your tests).
-    --app-name <app-name>                - App name to create or add tests to.
-    --devices <devices>                  - Device selection id from the Test Cloud upload dialog.
-    --async                              - Don't wait for the Test Cloud run to complete.
-    --async-json                         - Don't wait for the Test Cloud run to complete and output async results in json format.
-    --locale <locale>                    - System language (en_US by default)
-    --series <series>                    - Test series name.
-    --dsym-directory <dsym-directory>    - Optional dSYM directory for iOS crash symbolication.
-    --test-parameters <cspairs>          - Comma-separated test parameters (e.g. user:nat@xamarin.com,password:xamarin)
-    --debug                              - Prints out more debug information.
-";
-
-        public static readonly string[] OptionsSyntax =
-        {
-            "<app-file> <api-key> --user <user> --devices <devices> --workspace <workspace> [options]"
-        };
-
-        public static readonly string[] XCUITestOptionsSyntax = 
-        {
-            "<api-key> --user <user> --devices <devices> --workspace <workspace> [options]"
-        };
-
-        private readonly IDictionary<string, ValueObject> _options;
-        private IList<KeyValuePair<string, string>> _parsedTestParameters;
-
-        public UploadTestsCommandOptions(IDictionary<string, ValueObject> options)
-        {
-            if (options == null)
-                throw new ArgumentNullException(nameof(options));
-
-            _options = options;
-            _parsedTestParameters = null;
+        public static string OptionsDescription() {
+            return  @"
+                <app-file>                           - An Android or iOS application to test.
+                <api-key>                            - Test Cloud API key.
+                --user <user>                        - Email address of the user.
+                --workspace <workspace>              - Path to the workspace folder (containing your tests).
+                --app-name <app-name>                - App name to create or add tests to.
+                --devices <devices>                  - Device selection id from the Test Cloud upload dialog.
+                --async                              - Don't wait for the Test Cloud run to complete.
+                --async-json                         - Don't wait for the Test Cloud run to complete and output async results in json format.
+                --locale <locale>                    - System language (en_US by default)
+                --series <series>                    - Test series name.
+                --dsym-directory <dsym-directory>    - Optional dSYM directory for iOS crash symbolication.
+                --test-parameters <cspairs>          - Comma-separated test parameters (e.g. user:nat@xamarin.com,password:xamarin)
+                --debug                              - Prints out more debug information.
+            ";
         }
 
-        public void Validate(bool appRequired = true)
+        public static string[] OptionsSyntax()
         {
-            ValidateRequiredOptions(appRequired);
+            return new [] { "<app-file> <api-key> --user <user> --devices <devices> --workspace <workspace> [options]" };
         }
 
-        protected virtual void ValidateRequiredOptions(bool appRequired)
+        public UploadTestsCommandOptions(IDictionary<string, ValueObject> options) : base(options) {}
+
+        public override void Validate()
         {
-            if (appRequired && !File.Exists(this.AppFile))
+            ValidateRequiredOptions();
+        }
+
+        protected virtual void ValidateRequiredOptions()
+        {
+            if (!File.Exists(this.AppFile))
             {
                 throw new CommandException(
                     UploadTestsCommand.CommandName, 
@@ -117,121 +88,5 @@ namespace Microsoft.Xtc.TestCloud.Commands
                 _parsedTestParameters = ParseTestParameters(_options[TestParametersOption]?.ToString()).ToList();
             }
         }
-
-        private string _appFile;
-
-        public string AppFile
-        {
-            get { return _appFile ?? 
-                (_options.ContainsKey(AppFileOption) ? _options[AppFileOption].ToString() : null); }
-            set { _appFile = value; }
-        }
-
-        public string ApiKey
-        {
-            get { return _options[ApiKeyOption].ToString(); }
-        }
-
-        public string User
-        {
-            get { return _options[UserOption]?.ToString(); }
-        }
-
-        public string Workspace
-        {
-            get { return _options[WorkspaceOption]?.ToString(); }
-        }
-
-        public string AppName
-        {
-            get { return _options[AppNameOption]?.ToString(); }
-        }
-
-        public string Devices
-        {
-            get { return _options[DevicesOption]?.ToString(); }
-        }
-
-        public IList<KeyValuePair<string, string>> TestParameters
-        {
-            get 
-            {
-                if (_parsedTestParameters == null)
-                    _parsedTestParameters = ParseTestParameters(_options[TestParametersOption]?.ToString()).ToList();
-                 
-                return _parsedTestParameters;
-            }
-        }
-
-        public bool Async
-        {
-            get { return _options[AsyncOption].IsTrue; }
-        }
-
-        public bool AsyncJson
-        {
-            get { return _options[AsyncJsonOption].IsTrue; }
-        }
-
-        public string Locale
-        {
-            get { return _options[LocaleOption]?.ToString() ?? "en_US"; }
-        }
-
-        public string Series
-        {
-            get { return _options[SeriesOption]?.ToString(); }
-        }
-
-        public string DSymDirectory
-        {
-            get { return _options[DSymDirectoryOption]?.ToString(); }
-        }
-
-        public bool Debug
-        {
-            get { return _options[DebugOption].IsTrue; }
-        }
-
-        private IEnumerable<KeyValuePair<string, string>> ParseTestParameters(string testParametersString)
-        {
-            if (string.IsNullOrWhiteSpace(testParametersString))
-                return Enumerable.Empty<KeyValuePair<string, string>>();
-
-            var regex = new Regex("((?<key>.+):(?<value>.+))");
-            var pairs = Regex.Split(testParametersString, "\\s*,\\s*");
-            
-            if (pairs.Any(p => !regex.IsMatch(p)))
-            {
-                throw new CommandException(
-                    UploadTestsCommand.CommandName, 
-                    $"Argument {TestParametersOption} is not formatted correctly", 
-                    (int)UploadCommandExitCodes.InvalidOptions);
-            }
-                
-            return pairs
-                .Select(pair => {
-                    var match = regex.Match(pair);
-                    return new KeyValuePair<string, string>(match.Groups["key"].Value, match.Groups["value"].Value);
-                });
-        }
-
-        public IList<string> ToArgumentsArray()
-        {
-            var result = new List<string>();
-
-            foreach (var keyValue in _options)
-            {
-                if (keyValue.Value != null)
-                {
-                    result.Add(keyValue.Key);
-                    if (keyValue.Value.IsString)
-                        result.Add(keyValue.Value.ToString());
-                }
-            }
-
-            return result;
-        }
-
     }
 }

--- a/Xtc/src/Xtc.TestCloud/Commands/UploadTestsCommandOptions.cs
+++ b/Xtc/src/Xtc.TestCloud/Commands/UploadTestsCommandOptions.cs
@@ -48,6 +48,11 @@ namespace Microsoft.Xtc.TestCloud.Commands
             "<app-file> <api-key> --user <user> --devices <devices> --workspace <workspace> [options]"
         };
 
+        public static readonly string[] XCUITestOptionsSyntax = 
+        {
+            "<api-key> --user <user> --devices <devices> --workspace <workspace> [options]"
+        };
+
         private readonly IDictionary<string, ValueObject> _options;
         private IList<KeyValuePair<string, string>> _parsedTestParameters;
 
@@ -60,14 +65,14 @@ namespace Microsoft.Xtc.TestCloud.Commands
             _parsedTestParameters = null;
         }
 
-        public void Validate()
+        public void Validate(bool appRequired = true)
         {
-            ValidateRequiredOptions();
+            ValidateRequiredOptions(appRequired);
         }
 
-        protected virtual void ValidateRequiredOptions()
+        protected virtual void ValidateRequiredOptions(bool appRequired)
         {
-            if (!File.Exists(this.AppFile))
+            if (appRequired && !File.Exists(this.AppFile))
             {
                 throw new CommandException(
                     UploadTestsCommand.CommandName, 
@@ -113,9 +118,13 @@ namespace Microsoft.Xtc.TestCloud.Commands
             }
         }
 
+        private string _appFile;
+
         public string AppFile
         {
-            get { return _options[AppFileOption].ToString(); }
+            get { return _appFile ?? 
+                (_options.ContainsKey(AppFileOption) ? _options[AppFileOption].ToString() : null); }
+            set { _appFile = value; }
         }
 
         public string ApiKey

--- a/Xtc/src/Xtc.TestCloud/Commands/UploadXCUITestCommandExecutor.cs
+++ b/Xtc/src/Xtc.TestCloud/Commands/UploadXCUITestCommandExecutor.cs
@@ -1,8 +1,9 @@
-using Microsoft.Extensions.Logging;
 using Microsoft.Xtc.Common.Services.Logging;
 using Microsoft.Xtc.TestCloud.ObjectModel;
 using Microsoft.Xtc.TestCloud.Utilities;
 using Microsoft.Xtc.Common.Cli.Commands;
+using System.IO;
+using System;
 
 namespace Microsoft.Xtc.TestCloud.Commands
 {
@@ -15,10 +16,31 @@ namespace Microsoft.Xtc.TestCloud.Commands
         {
             this.TestName = "xcuitest";
             this.Workspace = new XCUITestWorkspace(options.Workspace);
+            
+            if (_options.AppFile == null) {
+                var appBundle = XCUITestWorkspace.FindAUT(options.Workspace);
+                _options.AppFile = FileHelper.ArchiveAppBundle(appBundle);
+            }
         }
 
         protected override void ValidateOptions()
         {
+            if (_options.AppFile == null)
+            {
+                throw new CommandException(
+                    UploadXCUITestsCommand.CommandName,
+                    $"Appfile not provided and not found in workspace {_options.Workspace}",
+                    (int)UploadCommandExitCodes.MissingAppFile);
+            }
+            
+            if (!File.Exists(_options.AppFile))
+            {
+                throw new CommandException(
+                    UploadTestsCommand.CommandName, 
+                    $"Cannot find app file: {_options.AppFile}",
+                    (int)UploadCommandExitCodes.InvalidAppFile);
+            }
+
             if (ValidationHelper.IsAndroidApp(_options.AppFile)) 
             {
                 throw new CommandException(

--- a/Xtc/src/Xtc.TestCloud/Commands/UploadXCUITestCommandExecutor.cs
+++ b/Xtc/src/Xtc.TestCloud/Commands/UploadXCUITestCommandExecutor.cs
@@ -3,7 +3,6 @@ using Microsoft.Xtc.TestCloud.ObjectModel;
 using Microsoft.Xtc.TestCloud.Utilities;
 using Microsoft.Xtc.Common.Cli.Commands;
 using System.IO;
-using System;
 
 namespace Microsoft.Xtc.TestCloud.Commands
 {
@@ -11,16 +10,11 @@ namespace Microsoft.Xtc.TestCloud.Commands
     /// Command executor that uploads XCUITest tests to the Test Cloud.
     /// </summary>
     public class UploadXCUITestCommandExecutor : UploadXTCTestCommandExecutor
-    {
-        public UploadXCUITestCommandExecutor(UploadTestsCommandOptions options, ILoggerService loggerService, LogsRecorder logsRecorder) : base(options, loggerService, logsRecorder)
+    {   
+        public UploadXCUITestCommandExecutor(UploadXCUITestsCommandOptions options, ILoggerService loggerService, LogsRecorder logsRecorder) : base(options, loggerService, logsRecorder)
         {
             this.TestName = "xcuitest";
             this.Workspace = new XCUITestWorkspace(options.Workspace);
-            
-            if (_options.AppFile == null) {
-                var appBundle = XCUITestWorkspace.FindAUT(options.Workspace);
-                _options.AppFile = FileHelper.ArchiveAppBundle(appBundle);
-            }
         }
 
         protected override void ValidateOptions()

--- a/Xtc/src/Xtc.TestCloud/Commands/UploadXCUITestsCommand.cs
+++ b/Xtc/src/Xtc.TestCloud/Commands/UploadXCUITestsCommand.cs
@@ -4,9 +4,7 @@ using System.Text;
 using DocoptNet;
 using Microsoft.Xtc.Common.Cli.Commands;
 using Microsoft.Xtc.Common.Cli.Utilities;
-using Microsoft.Xtc.Common.Services;
 using Microsoft.Xtc.Common.Services.Logging;
-using Microsoft.Xtc.TestCloud.Services;
 using Microsoft.Xtc.TestCloud.Utilities;
 
 namespace Microsoft.Xtc.TestCloud.Commands
@@ -24,13 +22,13 @@ namespace Microsoft.Xtc.TestCloud.Commands
 Usage:
 {GetPossibleOptionSyntax()}
 
-Options: {UploadTestsCommandOptions.OptionsDescription}";
+Options: {UploadXCUITestsCommandOptions.OptionsDescription()}";
 
         private string GetPossibleOptionSyntax()
         {
             var result = new StringBuilder();
 
-            foreach (var syntax in UploadTestsCommandOptions.XCUITestOptionsSyntax)
+            foreach (var syntax in UploadXCUITestsCommandOptions.OptionsSyntax())
             {
                 result.AppendFormat($"    {ProgramUtilities.CurrentExecutableName} {this.Name} {syntax}");
             }
@@ -41,7 +39,7 @@ Options: {UploadTestsCommandOptions.OptionsDescription}";
         public ICommandExecutor CreateCommandExecutor(IDictionary<string, ValueObject> options, IServiceProvider serviceProvider)
         {
             var loggerService = (ILoggerService)serviceProvider.GetService(typeof(ILoggerService));
-            var uploadOptions = new UploadTestsCommandOptions(options);
+            var uploadOptions = new UploadXCUITestsCommandOptions(options);
             
             LogsRecorder logsRecorder = null;
 

--- a/Xtc/src/Xtc.TestCloud/Commands/UploadXCUITestsCommand.cs
+++ b/Xtc/src/Xtc.TestCloud/Commands/UploadXCUITestsCommand.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using DocoptNet;
+using Microsoft.Xtc.Common.Cli.Commands;
+using Microsoft.Xtc.Common.Cli.Utilities;
+using Microsoft.Xtc.Common.Services;
+using Microsoft.Xtc.Common.Services.Logging;
+using Microsoft.Xtc.TestCloud.Services;
+using Microsoft.Xtc.TestCloud.Utilities;
+
+namespace Microsoft.Xtc.TestCloud.Commands
+{
+    public class UploadXCUITestsCommand: ICommand
+    {
+        public const string CommandName = "xcuitest";
+
+        public string Name => CommandName;
+
+        public string Summary => "Upload xcuitests to the Test Cloud";
+
+        public string Syntax => $@"Command '{this.Name}': {this.Summary}. 
+
+Usage:
+{GetPossibleOptionSyntax()}
+
+Options: {UploadTestsCommandOptions.OptionsDescription}";
+
+        private string GetPossibleOptionSyntax()
+        {
+            var result = new StringBuilder();
+
+            foreach (var syntax in UploadTestsCommandOptions.XCUITestOptionsSyntax)
+            {
+                result.AppendFormat($"    {ProgramUtilities.CurrentExecutableName} {this.Name} {syntax}");
+            }
+
+            return result.ToString();
+        }
+
+        public ICommandExecutor CreateCommandExecutor(IDictionary<string, ValueObject> options, IServiceProvider serviceProvider)
+        {
+            var loggerService = (ILoggerService)serviceProvider.GetService(typeof(ILoggerService));
+            var uploadOptions = new UploadTestsCommandOptions(options);
+            
+            LogsRecorder logsRecorder = null;
+
+            if (uploadOptions.AsyncJson)
+            {
+                logsRecorder = new LogsRecorder();
+                loggerService.SetLoggerProvider(
+                    new RecordingLoggerProvider(loggerService.MinimumLogLevel, logsRecorder));
+            }
+
+            if (WorkspaceHelper.IsXCUITestWorkspace(uploadOptions.Workspace))
+            {
+                return new UploadXCUITestCommandExecutor(uploadOptions, loggerService, logsRecorder);
+            }
+            else
+            {
+                throw new CommandException(
+                    UploadTestsCommand.CommandName,
+                    @"Unable to recognize workspace format",
+                    (int) UploadCommandExitCodes.InvalidWorkspace);
+            }
+        }
+    }
+}

--- a/Xtc/src/Xtc.TestCloud/Commands/UploadXCUITestsCommandOptions.cs
+++ b/Xtc/src/Xtc.TestCloud/Commands/UploadXCUITestsCommandOptions.cs
@@ -1,0 +1,71 @@
+using Microsoft.Xtc.TestCloud.ObjectModel;
+using Microsoft.Xtc.Common.Cli.Commands;
+using Microsoft.Xtc.TestCloud.Utilities;
+using System.Collections.Generic;
+using DocoptNet;
+
+namespace Microsoft.Xtc.TestCloud.Commands
+{
+    /// <summary>
+    /// Represents command-line options for 'xcuitest' command.
+    /// </summary>
+    public class UploadXCUITestsCommandOptions: UploadTestsCommandOptions
+    {
+        public const string AppFileOptionFlag = "--app-file";
+
+        new public static string[] OptionsSyntax() 
+        {
+            return new [] { "<api-key> --user <user> --devices <devices> --workspace <workspace> [options]" };
+        }
+        new public static string OptionsDescription() {
+            return  @"
+                <api-key>                            - Test Cloud API key.
+                --app-file <app-file>                - iOS application to test
+                --user <user>                        - Email address of the user.
+                --workspace <workspace>              - Path to the workspace folder (containing your tests).
+                --app-name <app-name>                - App name to create or add tests to.
+                --devices <devices>                  - Device selection id from the Test Cloud upload dialog.
+                --async                              - Don't wait for the Test Cloud run to complete.
+                --async-json                         - Don't wait for the Test Cloud run to complete and output async results in json format.
+                --locale <locale>                    - System language (en_US by default)
+                --series <series>                    - Test series name.
+                --dsym-directory <dsym-directory>    - Optional dSYM directory for iOS crash symbolication.
+                --test-parameters <cspairs>          - Comma-separated test parameters (e.g. user:nat@xamarin.com,password:xamarin)
+                --debug                              - Prints out more debug information.
+            ";
+        }
+
+        public UploadXCUITestsCommandOptions(IDictionary<string, ValueObject> options) : base(options) {}
+
+        public override void Validate()
+        {
+            ValidateRequiredOptions();    
+        }
+
+        private string _appFile;
+
+        public override string AppFile
+        {
+            get 
+            {  
+                if (_options[AppFileOptionFlag] != null) 
+                {
+                    return _options[AppFileOptionFlag].ToString();
+                } 
+                if (_appFile == null) 
+                {
+                    var appBundle = XCUITestWorkspace.FindAUT(this.Workspace);
+                    if (appBundle == null)
+                    {
+                        throw new CommandException(
+                            UploadXCUITestsCommand.CommandName, 
+                            $"App file not specified and not found in workspace",
+                            (int)UploadCommandExitCodes.MissingAppFile);
+                    }
+                    _appFile= FileHelper.ArchiveAppBundle(appBundle);
+                }
+                return _appFile;
+            }
+        }
+    }
+}

--- a/Xtc/src/Xtc.TestCloud/Commands/UploadXTCTestCommandExecutor.cs
+++ b/Xtc/src/Xtc.TestCloud/Commands/UploadXTCTestCommandExecutor.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Xtc.TestCloud.Commands
 
         protected virtual void ValidateOptions()
         {
-            _options.Validate();
+            _options.Validate(false);
 
             if (ValidationHelper.IsAndroidApp(_options.AppFile))
             {

--- a/Xtc/src/Xtc.TestCloud/Commands/UploadXTCTestCommandExecutor.cs
+++ b/Xtc/src/Xtc.TestCloud/Commands/UploadXTCTestCommandExecutor.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Xtc.TestCloud.Commands
         private readonly LogsRecorder _logsRecorder;
         private readonly DSymDirectory _dSymDirectory;
 
-        protected readonly UploadTestsCommandOptions _options;
+        protected readonly IUploadTestsCommandOptions _options;
         private ILogger _logger;
         private IWorkspace _workspace;
         private string _testName;
@@ -46,7 +46,7 @@ namespace Microsoft.Xtc.TestCloud.Commands
         protected IWorkspace Workspace { get { return _workspace; } set { _workspace = value; } }
         protected string TestName { get { return _testName; } set { _testName = value; } }
 
-        public UploadXTCTestCommandExecutor(UploadTestsCommandOptions options, ILoggerService loggerService, LogsRecorder logsRecorder)
+        public UploadXTCTestCommandExecutor(IUploadTestsCommandOptions options, ILoggerService loggerService, LogsRecorder logsRecorder)
         {
             if (options == null)
                 throw new ArgumentNullException(nameof(options));
@@ -64,7 +64,7 @@ namespace Microsoft.Xtc.TestCloud.Commands
 
         protected virtual void ValidateOptions()
         {
-            _options.Validate(false);
+            _options.Validate();
 
             if (ValidationHelper.IsAndroidApp(_options.AppFile))
             {

--- a/Xtc/src/Xtc.TestCloud/ObjectModel/XCUITestWorkspace.cs
+++ b/Xtc/src/Xtc.TestCloud/ObjectModel/XCUITestWorkspace.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Text.RegularExpressions;
 using Microsoft.Xtc.Common.Cli.Commands;
 using Microsoft.Xtc.TestCloud.Commands;
 using Microsoft.Xtc.TestCloud.Utilities;
@@ -15,6 +16,15 @@ namespace Microsoft.Xtc.TestCloud.ObjectModel
     public class XCUITestWorkspace : IWorkspace
     {
         private readonly string _workspacePath;
+
+        public static string FindAUT(string workspacePath)
+        {
+            var regex = new Regex("^*[^-Runner].app$");
+            var apps =  Directory.GetDirectories(workspacePath)
+                        .Where(path => regex.IsMatch(path))
+                        .ToArray();
+            return apps.Length > 0 ? apps[0] : null;
+        }
 
         /// <summary>
         /// Constructor. Creates new instance of the XCUITest Workspace.

--- a/Xtc/src/Xtc.TestCloud/Utilities/FileHelper.cs
+++ b/Xtc/src/Xtc.TestCloud/Utilities/FileHelper.cs
@@ -57,6 +57,18 @@ namespace Microsoft.Xtc.TestCloud.Utilities
                 throw new InvalidOperationException("Can not archive an iOS application on Windows");
             }
 
+            if (!Path.GetExtension(appBundlePath).Equals(".app"))
+            {
+                throw new ArgumentException(
+                    $@"Expected bundle to end with .app, got ${appBundlePath}");
+            }
+
+            if (!Directory.Exists(appBundlePath))
+            {
+                throw new FileNotFoundException(
+                  $@"'${appBundlePath}' does not exist or is not a directory");
+            }
+
             // path/to/MyApp.ipa
             var ipaFilePath = Path.ChangeExtension(appBundlePath, ".ipa");
 

--- a/Xtc/test/Xtc.TestCloud.Tests/Commands/UploadTestsCommandOptionsTests.cs
+++ b/Xtc/test/Xtc.TestCloud.Tests/Commands/UploadTestsCommandOptionsTests.cs
@@ -210,6 +210,39 @@ namespace Microsoft.Xtc.TestCloud.Tests.Commands
         }
 
         [Fact]
+        public void ValidationShouldPassWithNoAppForXCUITestWithWorkspace() 
+        {
+            var args = new[] 
+            {
+                "xcuitest",
+                "testApiKey",
+                "--user", "testUser@xamarin.com",
+                "--devices", "testDevices",
+                "--workspace", "."
+            };
+
+            var uploadOptions = ParseOptions(args, true);
+            uploadOptions.Validate(false);
+        }
+
+        [Fact]
+        public void ValidationShouldFailWhenMissingRequiredApp() 
+        {
+            var args = new[] 
+            {
+                "xcuitest",
+                "testApiKey",
+                "--user", "testUser@xamarin.com",
+                "--devices", "testDevices",
+                "--workspace", "."
+            };
+
+            var uploadOptions = ParseOptions(args, true);
+
+            Assert.Throws<CommandException>(() => uploadOptions.Validate());
+        }
+
+        [Fact]
         public void ValidationShouldPassWhenAllRequiredOptionsAreCorrect()
         {
             var args = new[] 
@@ -245,9 +278,17 @@ namespace Microsoft.Xtc.TestCloud.Tests.Commands
             Assert.Throws<DocoptInputErrorException>(() => new Docopt().Apply(command.Syntax, args));
         }
 
-        private UploadTestsCommandOptions ParseOptions(string[] args)
+        private UploadTestsCommandOptions ParseOptions(string[] args, bool forXCUITest = false)
         {
-            var command = new UploadTestsCommand();
+            ICommand command;
+            if (forXCUITest) 
+            { 
+                command = new UploadXCUITestsCommand();
+            }
+            else
+            {
+                command = new UploadTestsCommand();
+            }
             var docoptOptions = new Docopt().Apply(command.Syntax, args);
             
             return new UploadTestsCommandOptions(docoptOptions);

--- a/Xtc/test/Xtc.TestCloud.Tests/Commands/UploadTestsCommandOptionsTests.cs
+++ b/Xtc/test/Xtc.TestCloud.Tests/Commands/UploadTestsCommandOptionsTests.cs
@@ -209,42 +209,6 @@ namespace Microsoft.Xtc.TestCloud.Tests.Commands
             Assert.Throws<CommandException>(() => uploadOptions.Validate());
         }
 
-        //TODO: Move
-        [Fact]
-        public void ValidationShouldFailWhenSpecifiedAppDoesNotExist() 
-        {
-            var args = new[] 
-            {
-                "xcuitest",
-                "testApiKey",
-                "--app-file", "someapp.ipa",
-                "--user", "testUser@xamarin.com",
-                "--devices", "testDevices",
-                "--workspace", "."
-            };
-
-            var uploadOptions = ParseOptions(args, forXCUITest:true);
-            Assert.Throws<CommandException>(() => uploadOptions.Validate());
-        }
-
-        //TODO: Move
-        [Fact]
-        public void ValidationShouldFailWhenAppsNotFoundInWorkspace() 
-        {
-            var args = new[] 
-            {
-                "xcuitest",
-                "testApiKey",
-                "--user", "testUser@xamarin.com",
-                "--devices", "testDevices",
-                "--workspace", "."
-            };
-
-            var uploadOptions = ParseOptions(args, forXCUITest:true);
-
-            Assert.Throws<CommandException>(() => uploadOptions.Validate());
-        }
-
         [Fact]
         public void ValidationShouldPassWhenAllRequiredOptionsAreCorrect()
         {
@@ -281,21 +245,11 @@ namespace Microsoft.Xtc.TestCloud.Tests.Commands
             Assert.Throws<DocoptInputErrorException>(() => new Docopt().Apply(command.Syntax, args));
         }
 
-        private UploadTestsCommandOptions ParseOptions(string[] args, bool forXCUITest = false)
+        private UploadTestsCommandOptions ParseOptions(string[] args)
         {
-            ICommand command;
-            if (forXCUITest) 
-            { 
-                command = new UploadXCUITestsCommand();
-                var docoptOptions = new Docopt().Apply(command.Syntax, args);
-                return new UploadXCUITestsCommandOptions(docoptOptions);
-            }
-            else
-            {
-                command = new UploadTestsCommand();
-                var docoptOptions = new Docopt().Apply(command.Syntax, args);
-                return new UploadTestsCommandOptions(docoptOptions);
-            }
+            ICommand command = new UploadTestsCommand();
+            var docoptOptions = new Docopt().Apply(command.Syntax, args);
+            return new UploadTestsCommandOptions(docoptOptions);
         }
     }
 }

--- a/Xtc/test/Xtc.TestCloud.Tests/Commands/UploadTestsCommandOptionsTests.cs
+++ b/Xtc/test/Xtc.TestCloud.Tests/Commands/UploadTestsCommandOptionsTests.cs
@@ -209,24 +209,27 @@ namespace Microsoft.Xtc.TestCloud.Tests.Commands
             Assert.Throws<CommandException>(() => uploadOptions.Validate());
         }
 
+        //TODO: Move
         [Fact]
-        public void ValidationShouldPassWithNoAppForXCUITestWithWorkspace() 
+        public void ValidationShouldFailWhenSpecifiedAppDoesNotExist() 
         {
             var args = new[] 
             {
                 "xcuitest",
                 "testApiKey",
+                "--app-file", "someapp.ipa",
                 "--user", "testUser@xamarin.com",
                 "--devices", "testDevices",
                 "--workspace", "."
             };
 
-            var uploadOptions = ParseOptions(args, true);
-            uploadOptions.Validate(false);
+            var uploadOptions = ParseOptions(args, forXCUITest:true);
+            Assert.Throws<CommandException>(() => uploadOptions.Validate());
         }
 
+        //TODO: Move
         [Fact]
-        public void ValidationShouldFailWhenMissingRequiredApp() 
+        public void ValidationShouldFailWhenAppsNotFoundInWorkspace() 
         {
             var args = new[] 
             {
@@ -237,7 +240,7 @@ namespace Microsoft.Xtc.TestCloud.Tests.Commands
                 "--workspace", "."
             };
 
-            var uploadOptions = ParseOptions(args, true);
+            var uploadOptions = ParseOptions(args, forXCUITest:true);
 
             Assert.Throws<CommandException>(() => uploadOptions.Validate());
         }
@@ -284,14 +287,15 @@ namespace Microsoft.Xtc.TestCloud.Tests.Commands
             if (forXCUITest) 
             { 
                 command = new UploadXCUITestsCommand();
+                var docoptOptions = new Docopt().Apply(command.Syntax, args);
+                return new UploadXCUITestsCommandOptions(docoptOptions);
             }
             else
             {
                 command = new UploadTestsCommand();
+                var docoptOptions = new Docopt().Apply(command.Syntax, args);
+                return new UploadTestsCommandOptions(docoptOptions);
             }
-            var docoptOptions = new Docopt().Apply(command.Syntax, args);
-            
-            return new UploadTestsCommandOptions(docoptOptions);
         }
     }
 }

--- a/Xtc/test/Xtc.TestCloud.Tests/Commands/UploadXCUITestsCommandOptionsTests.cs
+++ b/Xtc/test/Xtc.TestCloud.Tests/Commands/UploadXCUITestsCommandOptionsTests.cs
@@ -1,0 +1,51 @@
+using DocoptNet;
+using Microsoft.Xtc.Common.Cli.Commands;
+using Microsoft.Xtc.TestCloud.Commands;
+using Xunit;
+
+namespace Microsoft.Xtc.TestCloud.Tests.Commands
+{
+    public class UploadXCUITestsCommandOptionsTests
+    {
+        [Fact]
+        public void ValidationShouldFailWhenSpecifiedAppDoesNotExist() 
+        {
+            var args = new[] 
+            {
+                "xcuitest",
+                "testApiKey",
+                "--app-file", "someapp.ipa",
+                "--user", "testUser@xamarin.com",
+                "--devices", "testDevices",
+                "--workspace", "."
+            };
+
+            var uploadOptions = ParseOptions(args);
+            Assert.Throws<CommandException>(() => uploadOptions.Validate());
+        }
+
+        [Fact]
+        public void ValidationShouldFailWhenAppsNotFoundInWorkspace() 
+        {
+            var args = new[] 
+            {
+                "xcuitest",
+                "testApiKey",
+                "--user", "testUser@xamarin.com",
+                "--devices", "testDevices",
+                "--workspace", "."
+            };
+
+            var uploadOptions = ParseOptions(args);
+
+            Assert.Throws<CommandException>(() => uploadOptions.Validate());
+        }
+
+        private UploadTestsCommandOptions ParseOptions(string[] args)
+        {
+            ICommand command = new UploadXCUITestsCommand();
+            var docoptOptions = new Docopt().Apply(command.Syntax, args);
+            return new UploadXCUITestsCommandOptions(docoptOptions);
+        }
+    }
+}

--- a/Xtc/test/Xtc.TestCloud.Tests/Utilities/FileHelperTests.cs
+++ b/Xtc/test/Xtc.TestCloud.Tests/Utilities/FileHelperTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.Xtc.Common.Services;
@@ -66,6 +67,23 @@ namespace Microsoft.Xtc.TestCloud.Tests.Utilities
             var windowsPlatform = new TestPlatformService() { CurrentPlatform = OSPlatform.Windows };
 
             Assert.Equal("Dir2/Foo.bar", FileHelper.GetRelativePath(filePath, rootDirectoryPath, windowsPlatform));
+        }
+
+        [Fact]
+        public void ArchiveAppBundleShouldFailForInvalidFileTypes()
+        {
+            var invalid = new string[] { "bluemoon.txt", "bluemoon.ipa", "bluemoon.apk", "bluemoon" };
+            foreach (string invalidAppname in invalid) 
+            {
+                Assert.Throws<ArgumentException>(() => FileHelper.ArchiveAppBundle(invalidAppname));
+            }
+        }
+
+        [Fact]
+        public void ArchiveAppBundleShouldFailIfFileDoesNotExist()
+        {
+            var imaginary = "Unicorn.app";
+            Assert.Throws<FileNotFoundException>(() => FileHelper.ArchiveAppBundle(imaginary));
         }
     } 
 }


### PR DESCRIPTION
### WIP

# Motivation

Support this format:
```Shell
$ xtc xcuitest  <api_key> --devices a1801a3c --user jenkins_qa@nonexistingemail.com --workspace ~/Somewhere/Build/Products/Debug-iphoneos/
```

And this:

```Shell
$ xtc xcuitest  <api_key> --app-file myApp.ipa --devices a1801a3c --user jenkins_qa@nonexistingemail.com --workspace ~/Somewhere/Build/Products/Debug-iphoneos/
```

# Note

To use this format, the command is `xcuitest`.

# TODO:

- [ ] Refactor unit tests, need to create new `UploadXCUITestCommandOptions.cs` file
- [ ] Test that xcuitests are not supported using `test` command
- [ ] Test that `--app-file` takes precedence over whatever AUT is in the workspace
- [ ] Some sanity tests on the `ArchiveBundle` function to check that directories exist etc.