### PR TITLE
Feature/fix ipa exists error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ publish
 Xtc/publish
 project.lock.json
 restore.dg
+Xtc.userprefs

--- a/Xtc/test/Xtc.TestCloud.Tests/Utilities/FileHelperTests.cs
+++ b/Xtc/test/Xtc.TestCloud.Tests/Utilities/FileHelperTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Xtc.TestCloud.Tests.Utilities
         }
 
         [Fact]
-        public void ArchiveAppBundleShouldSucceedApiFileExists()
+        public void ArchiveAppBundleShouldSucceedIpaFileExists()
         {
             var real = "Dragon.app";
             Directory.CreateDirectory(real);
@@ -113,7 +113,7 @@ namespace Microsoft.Xtc.TestCloud.Tests.Utilities
         }
 
         [Fact]
-        public void ArchiveAppBundleShouldSucceedApiFileExistsNotDitto()
+        public void ArchiveAppBundleShouldSucceedIpaFileExistsNotDitto()
         {
             var real = "Dragon.app";
             Directory.CreateDirectory(real);

--- a/Xtc/test/Xtc.TestCloud.Tests/Utilities/FileHelperTests.cs
+++ b/Xtc/test/Xtc.TestCloud.Tests/Utilities/FileHelperTests.cs
@@ -112,19 +112,19 @@ namespace Microsoft.Xtc.TestCloud.Tests.Utilities
             File.Delete("Dragon.ipa");
         }
 
-		[Fact]
-		public void ArchiveAppBundleShouldSucceedApiFileExistsNotDitto()
-		{
-			var real = "Dragon.app";
-			Directory.CreateDirectory(real);
-			var file = System.IO.File.Create("Dragon.ipa");
-			var writer = new System.IO.StreamWriter(file);
-			writer.WriteLine("Here be dragons");
-			writer.Dispose();
-			FileHelper.ArchiveAppBundle(real, true);
-			Assert.True(File.Exists("Dragon.ipa"));
-			Directory.Delete(real);
-			File.Delete("Dragon.ipa");
-		}
+        [Fact]
+        public void ArchiveAppBundleShouldSucceedApiFileExistsNotDitto()
+        {
+            var real = "Dragon.app";
+            Directory.CreateDirectory(real);
+            var file = System.IO.File.Create("Dragon.ipa");
+            var writer = new System.IO.StreamWriter(file);
+            writer.WriteLine("Here be dragons");
+            writer.Dispose();
+            FileHelper.ArchiveAppBundle(real, true);
+            Assert.True(File.Exists("Dragon.ipa"));
+            Directory.Delete(real);
+            File.Delete("Dragon.ipa");
+        }
     } 
 }

--- a/Xtc/test/Xtc.TestCloud.Tests/Utilities/FileHelperTests.cs
+++ b/Xtc/test/Xtc.TestCloud.Tests/Utilities/FileHelperTests.cs
@@ -85,5 +85,46 @@ namespace Microsoft.Xtc.TestCloud.Tests.Utilities
             var imaginary = "Unicorn.app";
             Assert.Throws<FileNotFoundException>(() => FileHelper.ArchiveAppBundle(imaginary));
         }
+
+        [Fact]
+        public void ArchiveAppBundleShouldSucceedAppFileExists()
+        {
+            var real = "Dragon.app";
+            Directory.CreateDirectory(real);
+            FileHelper.ArchiveAppBundle(real);
+            Assert.True(File.Exists("Dragon.ipa"));
+            Directory.Delete(real);
+            File.Delete("Dragon.ipa");
+        }
+
+        [Fact]
+        public void ArchiveAppBundleShouldSucceedApiFileExists()
+        {
+            var real = "Dragon.app";
+            Directory.CreateDirectory(real);
+            var file = System.IO.File.Create("Dragon.ipa");
+            var writer = new System.IO.StreamWriter(file);
+            writer.WriteLine("Here be dragons");
+            writer.Dispose();
+            FileHelper.ArchiveAppBundle(real);
+            Assert.True(File.Exists("Dragon.ipa"));
+            Directory.Delete(real);
+            File.Delete("Dragon.ipa");
+        }
+
+		[Fact]
+		public void ArchiveAppBundleShouldSucceedApiFileExistsNotDitto()
+		{
+			var real = "Dragon.app";
+			Directory.CreateDirectory(real);
+			var file = System.IO.File.Create("Dragon.ipa");
+			var writer = new System.IO.StreamWriter(file);
+			writer.WriteLine("Here be dragons");
+			writer.Dispose();
+			FileHelper.ArchiveAppBundle(real, true);
+			Assert.True(File.Exists("Dragon.ipa"));
+			Directory.Delete(real);
+			File.Delete("Dragon.ipa");
+		}
     } 
 }


### PR DESCRIPTION
# Motivation
Test app rakefile was broken when the -Runner.ipa file already existed (only when `ditto` not available - i.e. on Linux).

# Fix
This fix for [this VSTS Ticket](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/22788)

Also fixes some whitespace issues.